### PR TITLE
Habilita generar compras desde pedidos a proveedor

### DIFF
--- a/src/expendioproyecto/controlador/FXMLCompraController.java
+++ b/src/expendioproyecto/controlador/FXMLCompraController.java
@@ -6,6 +6,7 @@ import expendioproyecto.modelo.ConexionBD;
 import expendioproyecto.modelo.pojo.Bebida;
 import expendioproyecto.modelo.pojo.BebidaCompra;
 import expendioproyecto.modelo.pojo.Proveedor;
+import expendioproyecto.modelo.pojo.BebidaPedidoProveedor;
 import expendioproyecto.modelo.pojo.Usuario;
 import expendioproyecto.utilidad.Utilidad;
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import javafx.beans.property.FloatProperty;
@@ -311,5 +313,23 @@ public class FXMLCompraController implements Initializable {
         }
     }
 
-    
+    public void cargarPedidoProveedor(List<BebidaPedidoProveedor> pedidoProveedor) {
+        listaCompra.clear();
+        totalCompra.set(0);
+
+        for (BebidaPedidoProveedor pedido : pedidoProveedor) {
+            Bebida bebida = pedido.getBebida();
+            if (bebida == null) {
+                continue;
+            }
+
+            BebidaCompra compra = new BebidaCompra(bebida, pedido.getCantidadSugerida(), bebida.getPrecio());
+            listaCompra.add(compra);
+            totalCompra.set(totalCompra.get() + compra.getSubtotal());
+        }
+
+        tfTotalCompra.setText(String.format("$ %.2f", totalCompra.get()));
+    }
+
+
 }

--- a/src/expendioproyecto/controlador/FXMLPedidosProveedorController.java
+++ b/src/expendioproyecto/controlador/FXMLPedidosProveedorController.java
@@ -18,6 +18,7 @@ import expendioproyecto.utilidad.Utilidad;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -67,6 +68,8 @@ public class FXMLPedidosProveedorController implements Initializable {
     private MenuItem btnExportarPDF;
     @FXML
     private Button btnAgregarBebida;
+    @FXML
+    private Button btnGenerarCompra;
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
@@ -173,6 +176,33 @@ public class FXMLPedidosProveedorController implements Initializable {
             listaPedidoAuto.add(nuevo); 
         }
         tvBebidasAPedir.refresh(); // actualiza la tabla
+    }
+
+    @FXML
+    private void btnClicGenerarCompra(ActionEvent event) {
+        if (listaPedidoAuto.isEmpty()) {
+            Utilidad.mostrarAlertaSimple(Alert.AlertType.INFORMATION, "Sin productos", "No hay bebidas en el pedido para generar una compra.");
+            return;
+        }
+
+        try {
+            Stage escenarioBase = Utilidad.getEscenarioComponente(btnGenerarCompra);
+            FXMLLoader cargador = new FXMLLoader(ExpendioProyecto.class.getResource("vista/FXMLCompra.fxml"));
+            Parent vista = cargador.load();
+
+            FXMLCompraController controlador = cargador.getController();
+            controlador.setUsuario(usuario);
+            controlador.cargarPedidoProveedor(new ArrayList<>(listaPedidoAuto));
+
+            Scene escena = new Scene(vista);
+            escenarioBase.setScene(escena);
+            escenarioBase.setTitle("Compras");
+            escenarioBase.centerOnScreen();
+            escenarioBase.show();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            Utilidad.mostrarAlertaSimple(Alert.AlertType.ERROR, "Error al generar compra", "Ocurrió un error al abrir la ventana de compras.");
+        }
     }
 
     @FXML

--- a/src/expendioproyecto/modelo/pojo/BebidaPedidoProveedor.java
+++ b/src/expendioproyecto/modelo/pojo/BebidaPedidoProveedor.java
@@ -4,12 +4,14 @@ import javafx.beans.property.*;
 
 public class BebidaPedidoProveedor {
 
+    private final Bebida bebida;
     private final StringProperty nombre;
     private final StringProperty descripcion;
     private final IntegerProperty cantidadSugerida;
     private final int idProducto;
 
     public BebidaPedidoProveedor(Bebida bebida) {
+        this.bebida = bebida;
         this.nombre = new SimpleStringProperty(bebida.getNombre());
         this.descripcion = new SimpleStringProperty(bebida.getDescripcion());
         this.idProducto = bebida.getIdProducto();
@@ -19,6 +21,7 @@ public class BebidaPedidoProveedor {
     }
 
     public BebidaPedidoProveedor(Bebida bebida, int cantidad) {
+        this.bebida = bebida;
         this.nombre = new SimpleStringProperty(bebida.getNombre());
         this.descripcion = new SimpleStringProperty(bebida.getDescripcion());
         this.idProducto = bebida.getIdProducto();
@@ -37,6 +40,10 @@ public class BebidaPedidoProveedor {
 
     public int getCantidadSugerida() {
         return cantidadSugerida.get();
+    }
+
+    public Bebida getBebida() {
+        return bebida;
     }
 
     public int getIdProducto() {

--- a/src/expendioproyecto/vista/FXMLPedidosProveedor.fxml
+++ b/src/expendioproyecto/vista/FXMLPedidosProveedor.fxml
@@ -34,6 +34,7 @@
          </font>
       </Label>
       <Button fx:id="btnAgregarBebida" layoutX="431.0" layoutY="536.0" mnemonicParsing="false" onAction="#btnCliAgregarBebida" prefHeight="49.0" prefWidth="145.0" style="-fx-background-color: #ffa333; -fx-cursor: hand;" text="Agregar Bebida" />
+      <Button fx:id="btnGenerarCompra" layoutX="282.0" layoutY="536.0" mnemonicParsing="false" onAction="#btnClicGenerarCompra" prefHeight="49.0" prefWidth="145.0" style="-fx-background-color: #ffa333; -fx-cursor: hand;" text="Generar compra" />
       <MenuButton layoutX="600.0" layoutY="545.0" mnemonicParsing="false" style="-fx-background-color: #ffa333; -fx-cursor: hand;" text="Exportar Infromación">
          <items>
             <MenuItem fx:id="btnExportarXLSX" mnemonicParsing="false" onAction="#btnClicExportarXLSX" text="EXCEL (XLSX)" />


### PR DESCRIPTION
## Summary
- añade un botón de "Generar compra" en la vista de pedidos a proveedor que abre la pantalla de compras con el pedido cargado
- reutiliza las cantidades sugeridas para poblar la lista de productos de la compra desde el controlador de compras
- guarda la referencia a la bebida original en los elementos del pedido para poder convertirlos en partidas de compra

## Testing
- no tests run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e630051c2c832db5b134a0a0697677